### PR TITLE
Make all dependencies static

### DIFF
--- a/enclaver/Cargo.lock
+++ b/enclaver/Cargo.lock
@@ -698,7 +698,7 @@ dependencies = [
 [[package]]
 name = "bollard"
 version = "0.18.1"
-source = "git+https://github.com/fussybeaver/bollard.git?branch=master#88ed8a71da87278726322a84439ec3d3eaf28b1e"
+source = "git+https://github.com/fussybeaver/bollard.git?rev=526f9b8bdbdf58ebbed898d184fbfb4fcef29e69#526f9b8bdbdf58ebbed898d184fbfb4fcef29e69"
 dependencies = [
  "base64 0.22.1",
  "bollard-stubs",
@@ -1575,7 +1575,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.8",
  "tokio",
  "tower-service",
  "tracing",
@@ -1703,7 +1703,7 @@ dependencies = [
  "http-body 1.0.1",
  "hyper 1.6.0",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.8",
  "tokio",
  "tower-service",
  "tracing",
@@ -1925,6 +1925,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-uring"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
+dependencies = [
+ "bitflags 2.9.0",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2013,9 +2024,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.170"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libloading"
@@ -2516,7 +2527,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.25",
- "socket2",
+ "socket2 0.5.8",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -2551,7 +2562,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.5.8",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -3169,6 +3180,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3394,21 +3415,23 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.43.0"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "slab",
+ "socket2 0.6.0",
  "tokio-macros",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/enclaver/Cargo.toml
+++ b/enclaver/Cargo.toml
@@ -43,7 +43,7 @@ serde_bytes = "0.11"
 serde = { version = "1.0", features = ["derive"] }
 json = "0.12"
 base64 = "0.13"
-bollard = { git = "https://github.com/fussybeaver/bollard.git", branch = "master" }
+bollard = { git = "https://github.com/fussybeaver/bollard.git", rev = "526f9b8bdbdf58ebbed898d184fbfb4fcef29e69" }
 tempfile = "3.10"
 http = "1.3"
 http-body = "1.0"

--- a/enclaver/src/build.rs
+++ b/enclaver/src/build.rs
@@ -19,10 +19,10 @@ use uuid::Uuid;
 const ENCLAVE_OVERLAY_CHOWN: &str = "0:0";
 const RELEASE_OVERLAY_CHOWN: &str = "0:0";
 
-const NITRO_CLI_IMAGE: &str = "registry.edgebit.io/nitro-cli:latest";
-const ODYN_IMAGE: &str = "registry.edgebit.io/odyn:latest";
+const NITRO_CLI_IMAGE: &str = "registry.edgebit.io/nitro-cli@sha256:e60304c83857bbada5288d7536817bf0da53a8790638f0d5ffa38d95ae4fb080";
+const ODYN_IMAGE: &str = "registry.edgebit.io/odyn@sha256:fb01cd2d789d5bed59353e3eceb093ed4466d3dab25037479d284647ed48a853";
 const ODYN_IMAGE_BINARY_PATH: &str = "/usr/local/bin/odyn";
-const RELEASE_BASE_IMAGE: &str = "registry.edgebit.io/enclaver-wrapper-base:latest";
+const RELEASE_BASE_IMAGE: &str = "registry.edgebit.io/enclaver-wrapper-base@sha256:9d03877a7d97dc1d187deff152dc1f7e440426f8245f7d4bc2b85017cd96c679";
 
 pub struct EnclaveArtifactBuilder {
     docker: Arc<Docker>,


### PR DESCRIPTION
This PR ensures the project uses only static dependencies. This is important so we can have reproducible builds.