### PR TITLE
fix(kms): Include `SharedSecret` plaintext in response when calling `DeriveSharedSecret`

### DIFF
--- a/enclaver/src/proxy/kms.rs
+++ b/enclaver/src/proxy/kms.rs
@@ -339,7 +339,14 @@ impl KmsProxyHandler {
             let ciphertext = base64::decode(b64ciphertext)?;
             let plaintext = self.decrypt_cms(&ciphertext)?;
 
-            body_obj["Plaintext"] = json::JsonValue::String(base64::encode(plaintext));
+            let field_name = if body_obj.get("KeyAgreementAlgorithm").is_some() {
+                // DeriveSharedSecret
+                "SharedSecret"
+            } else {
+                // Default for Decrypt, GenerateDataKey, etc.
+                "Plaintext"
+            };
+            body_obj[field_name] = json::JsonValue::String(base64::encode(plaintext));
             Ok(json_response(head, JsonValue::Object(body_obj)))
         } else {
             Err(anyhow!("The response body is not a JSON object"))


### PR DESCRIPTION
This PR aims to address issue #221 , the missing `SharedSecret` field in the response to `DeriveSharedSecret`.

The fix is to put the decrypted plaintext in the `SharedSecret` field, if the `KeyAgreementAlgorithm` field is present in the response. Otherwise, we put the data in the `Plaintext` field, which is the current behavior.