### PR TITLE
feat: Dynamic EIF file names using manifest, use relative paths for defaults in enclaver-run

### DIFF
--- a/src/bin/enclaver-run/main.rs
+++ b/src/bin/enclaver-run/main.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use clap::{Parser, Subcommand};
-use enclaver::constants::{EIF_FILE_NAME, MANIFEST_FILE_NAME, RELEASE_BUNDLE_DIR};
+use enclaver::constants::{EIF_FILE_NAME, MANIFEST_FILE_NAME};
 use enclaver::manifest::load_manifest_raw;
 use enclaver::nitro_cli::NitroCLI;
 use enclaver::run::{Enclave, EnclaveExitStatus, EnclaveOpts};
@@ -105,7 +105,7 @@ async fn run(args: Cli) -> Result<CLISuccess> {
 }
 
 async fn dump_manifest() -> Result<CLISuccess> {
-    let manifest_path = PathBuf::from(RELEASE_BUNDLE_DIR).join(MANIFEST_FILE_NAME);
+    let manifest_path = PathBuf::from(MANIFEST_FILE_NAME);
     let (raw_manifest, _) = load_manifest_raw(&manifest_path).await?;
     stdout().write_all(&raw_manifest).await?;
 
@@ -113,7 +113,7 @@ async fn dump_manifest() -> Result<CLISuccess> {
 }
 
 async fn describe_eif() -> Result<CLISuccess> {
-    let eif_path = PathBuf::from(RELEASE_BUNDLE_DIR).join(EIF_FILE_NAME);
+    let eif_path = PathBuf::from(EIF_FILE_NAME);
     let cli = NitroCLI::new();
     let eif_info = cli.describe_eif(&eif_path).await?;
     let eif_info_bytes = serde_json::to_vec_pretty(&eif_info)?;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -2,11 +2,6 @@
 pub const EIF_FILE_NAME: &str = "application.eif";
 pub const MANIFEST_FILE_NAME: &str = "enclaver.yaml";
 
-pub const ENCLAVE_CONFIG_DIR: &str = "/etc/enclaver";
-pub const ENCLAVE_ODYN_PATH: &str = "/sbin/odyn";
-
-pub const RELEASE_BUNDLE_DIR: &str = "/enclave";
-
 // Port Constants
 
 // start "internal" ports above the 16-bit boundary (reserved for proxying TCP)

--- a/src/run.rs
+++ b/src/run.rs
@@ -1,5 +1,5 @@
 use crate::constants::{
-    APP_LOG_PORT, EIF_FILE_NAME, HTTP_EGRESS_VSOCK_PORT, MANIFEST_FILE_NAME, RELEASE_BUNDLE_DIR,
+    APP_LOG_PORT, EIF_FILE_NAME, HTTP_EGRESS_VSOCK_PORT, MANIFEST_FILE_NAME,
     STATUS_PORT,
 };
 use crate::manifest::{load_manifest, Defaults, Manifest};
@@ -49,7 +49,7 @@ impl Enclave {
     pub async fn new(opts: EnclaveOpts) -> Result<Self> {
         let eif_path = match opts.eif_path {
             Some(eif_path) => eif_path,
-            None => PathBuf::from(RELEASE_BUNDLE_DIR).join(EIF_FILE_NAME),
+            None => PathBuf::from(EIF_FILE_NAME),
         };
 
         // Test that the EIF exists
@@ -59,7 +59,7 @@ impl Enclave {
 
         let manifest_path = match opts.manifest_path {
             Some(manifest_path) => manifest_path,
-            None => PathBuf::from(RELEASE_BUNDLE_DIR).join(MANIFEST_FILE_NAME),
+            None => PathBuf::from(MANIFEST_FILE_NAME),
         };
 
         let manifest = load_manifest(&manifest_path).await?;


### PR DESCRIPTION
This PR sets the EIF file name dynamically using the name in the manifest, defaulting to `application.eif`. It also updates `enclaver-run` so that it uses relative paths by default, if the EIF or manifest is not provided.